### PR TITLE
LINKED_LIBS attempt to fix wasm build

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -4,6 +4,7 @@
 duckdb_extension_load(lua
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
+    LINKED_LIBS "$<TARGET_FILE:lua>"
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
per https://rusty.today/blog/testing-duckdb-wasm-extensions/
This may have some issue since the `lua` name is also being used by the extension, hopefully that is not a problem